### PR TITLE
Feature/post consultation changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.17.0 // indirect
+	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/internal/configschema/configschema.go
+++ b/internal/configschema/configschema.go
@@ -25,11 +25,11 @@ func NewServer() *Server {
 }
 
 func getConfigSchemaKey(req ConfigSchemaRequest) string {
-	return req.GetNamespace() + "-" + req.GetSchemaName() + "-" + req.GetVersion()
+	return req.GetNamespace() + "/" + req.GetSchemaName() + "/" + req.GetVersion()
 }
 
 func getConfigSchemaPrefix(req ConfigSchemaRequest) string {
-	return req.GetNamespace() + "-" + req.GetSchemaName()
+	return req.GetNamespace() + "/" + req.GetSchemaName()
 }
 
 func (s *Server) SaveConfigSchema(ctx context.Context, in *pb.SaveConfigSchemaRequest) (*pb.SaveConfigSchemaResponse, error) {
@@ -52,7 +52,7 @@ func (s *Server) SaveConfigSchema(ctx context.Context, in *pb.SaveConfigSchemaRe
 	if err != nil {
 		return &pb.SaveConfigSchemaResponse{
 			Status:  13,
-			Message: "Error while saving schema!",
+			Message: err.Error(),
 		}, nil
 	}
 	return &pb.SaveConfigSchemaResponse{

--- a/internal/configschema/configschema.go
+++ b/internal/configschema/configschema.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jtomic1/config-schema-service/internal/validators"
 	pb "github.com/jtomic1/config-schema-service/proto"
 	"github.com/xeipuuv/gojsonschema"
+	"golang.org/x/mod/semver"
 	"sigs.k8s.io/yaml"
 )
 
@@ -46,6 +47,19 @@ func (s *Server) SaveConfigSchema(ctx context.Context, in *pb.SaveConfigSchemaRe
 		return &pb.SaveConfigSchemaResponse{
 			Status:  13,
 			Message: "Error while instantiating database client!",
+		}, nil
+	}
+	latestVersion, err := repoClient.GetLatestVersionByPrefix(getConfigSchemaPrefix(in.GetSchemaDetails()))
+	if err != nil {
+		return &pb.SaveConfigSchemaResponse{
+			Status:  13,
+			Message: err.Error(),
+		}, nil
+	}
+	if semver.Compare(in.GetSchemaDetails().GetVersion(), latestVersion) != 1 {
+		return &pb.SaveConfigSchemaResponse{
+			Status:  3,
+			Message: "Provided version is not latest! Please provide a version that succeeds '" + latestVersion + "'!",
 		}, nil
 	}
 	err = repoClient.SaveConfigSchema(getConfigSchemaKey(in.GetSchemaDetails()), in.GetUser(), in.GetSchema())

--- a/internal/validators/validators.go
+++ b/internal/validators/validators.go
@@ -6,6 +6,7 @@ import (
 
 	pb "github.com/jtomic1/config-schema-service/proto"
 	"github.com/xeipuuv/gojsonschema"
+	"golang.org/x/mod/semver"
 	"sigs.k8s.io/yaml"
 )
 
@@ -52,6 +53,8 @@ func AreSchemaDetailsValid(schemaDetails *pb.ConfigSchemaDetails, isVersionRequi
 		return false, errors.New("Schema name cannot be empty!")
 	} else if isVersionRequired && schemaDetails.GetVersion() == "" {
 		return false, errors.New("Schema version cannot be empty!")
+	} else if isVersionRequired && !semver.IsValid(schemaDetails.GetVersion()) {
+		return false, errors.New("Schema version must be a valid SemVer string with 'v' prefix!")
 	} else if strings.Contains(schemaDetails.GetNamespace(), "/") || strings.Contains(schemaDetails.GetSchemaName(), "/") || strings.Contains(schemaDetails.GetVersion(), "/") {
 		return false, errors.New("Schema details must not contain '/'!")
 	}


### PR DESCRIPTION
- Added version checking according to SemVer
- Schema value is saved in JSON instead of YAML
- '/' is now used as key separator instead of '-'
- Duplicate keys are now explicitly disallowed instead of overwriting
- Schema value is now validated on input. Validation consists of checking whether the provided YAML can be converted into a valid JSON Schema
- Version field when fetching version history is now optional